### PR TITLE
Fix stale cache reloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "koa": "^2.15.3",
         "koa-bodyparser": "^4.4.1",
         "koa-router": "^12.0.1",
+        "lodash": "^4.17.21",
         "react-hotkeys-hook": "^4.5.0",
         "react-icons": "^5.0.1",
         "react-query": "^3.39.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "koa": "^2.15.3",
     "koa-bodyparser": "^4.4.1",
     "koa-router": "^12.0.1",
+    "lodash": "^4.17.21",
     "react-hotkeys-hook": "^4.5.0",
     "react-icons": "^5.0.1",
     "react-query": "^3.39.3",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -103,7 +103,7 @@ export default function App(): JSX.Element {
     if (availableVideos.isSuccess && availableTags.isSuccess && availableGalleries.isSuccess) {
       saveSelection(new Set(availableVideos.data), new Set(), new Set(availableGalleries.data))
     }
-  }, [availableVideos.isSuccess, availableTags.isSuccess, availableGalleries.isSuccess])
+  }, [availableVideos.data, availableTags.data, availableGalleries.data])
 
   const checkExecutables = async (): Promise<void> => {
     const executablesStatusResponse = await fetch(`${bi.SERVER_URL}/${bi.GET_EXECUTABLES_STATUS}`)

--- a/src/renderer/src/hooks/videos.ts
+++ b/src/renderer/src/hooks/videos.ts
@@ -1,4 +1,5 @@
 import {
+  QueryClient,
   UseMutateFunction,
   UseQueryResult,
   useMutation,
@@ -8,39 +9,129 @@ import {
 import bi from '../../../backend_interface'
 import { IDiffObj, IVideoFull, IVideoWithRelated } from '../../../types'
 
+const QUERIES = {
+  fetchAvailableVideos: async (): Promise<string[]> =>
+    fetch(`${bi.SERVER_URL}/${bi.GET_AVAILABLE_VIDEOS}`).then((res) => res.json()),
+
+  fetchAllVideos: async (): Promise<IVideoFull[]> =>
+    fetch(`${bi.SERVER_URL}/${bi.GET_ALL_VIDEOS}`).then((res) => res.json()),
+
+  fetchVideo: async (videoPath: string): Promise<IVideoWithRelated> =>
+    fetch(`${bi.SERVER_URL}/${bi.GET_VIDEO}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoPath: videoPath })
+    }).then((res) => res.json()),
+
+  createVideos: async (videoPaths: string[]): Promise<Response> =>
+    fetch(`${bi.SERVER_URL}/${bi.ADD_VIDEOS}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoPaths: videoPaths })
+    }),
+
+  generateTgp: async (videoPath: string): Promise<Response> =>
+    fetch(`${bi.SERVER_URL}/${bi.GENERATE_TGP}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoPath: videoPath })
+    }),
+
+  generateMissingTgps: async (): Promise<Response> =>
+    fetch(`${bi.SERVER_URL}/${bi.GENERATE_MISSING_TGPS}`),
+
+  deleteVideo: async (videoPathToRemove: string): Promise<Response> =>
+    fetch(`${bi.SERVER_URL}/${bi.DELETE_VIDEO}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoPath: videoPathToRemove })
+    }),
+
+  deleteMissingVideos: async (): Promise<Response> =>
+    fetch(`${bi.SERVER_URL}/${bi.DELETE_MISSING_VIDEOS}`),
+
+  updateVideoGalleries: async ([videoPath, galleriesDiffObj]: [
+    string,
+    IDiffObj
+  ]): Promise<Response> =>
+    fetch(`${bi.SERVER_URL}/${bi.UPDATE_VIDEO_GALLERIES}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoPath: videoPath, diffObj: galleriesDiffObj })
+    }),
+
+  updateVideoTags: async ([videoPath, tagsDiffObj]: [string, IDiffObj]): Promise<Response> =>
+    fetch(`${bi.SERVER_URL}/${bi.UPDATE_VIDEO_TAGS}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoPath: videoPath, diffObj: tagsDiffObj })
+    })
+}
+
+const INVALIDATE_CACHES = {
+  createVideos: async (queryClient: QueryClient): Promise<void[]> =>
+    Promise.all([
+      queryClient.invalidateQueries(['availableVideos']),
+      queryClient.invalidateQueries(['allVideos']),
+      queryClient.invalidateQueries(['allGalleries'])
+    ]),
+
+  generateTgp: async (queryClient: QueryClient): Promise<void[]> =>
+    Promise.all([
+      queryClient.invalidateQueries(['availableVideos']),
+      queryClient.invalidateQueries(['allVideos'])
+    ]),
+
+  generateMissingTgps: async (queryClient: QueryClient): Promise<void[]> =>
+    Promise.all([
+      queryClient.invalidateQueries(['availableVideos']),
+      queryClient.invalidateQueries(['allVideos'])
+    ]),
+
+  deleteVideo: async (queryClient: QueryClient): Promise<void[]> =>
+    Promise.all([
+      queryClient.invalidateQueries(['availableVideos']),
+      queryClient.invalidateQueries(['allVideos']),
+      queryClient.invalidateQueries(['allGalleries']),
+      queryClient.invalidateQueries(['allTags'])
+    ]),
+
+  deleteMissingVideos: async (queryClient: QueryClient): Promise<void[]> =>
+    Promise.all([
+      queryClient.invalidateQueries(['allVideos']),
+      queryClient.invalidateQueries(['allGalleries']),
+      queryClient.invalidateQueries(['allTags'])
+    ]),
+
+  updateVideoGalleries: async (queryClient: QueryClient): Promise<void[]> =>
+    Promise.all([
+      queryClient.invalidateQueries(['allVideos']),
+      queryClient.invalidateQueries(['allGalleries'])
+    ]),
+
+  updateVideoTags: async (queryClient: QueryClient): Promise<void[]> =>
+    Promise.all([
+      queryClient.invalidateQueries(['allVideos']),
+      queryClient.invalidateQueries(['allTags'])
+    ])
+}
+
 export function useAvailableVideos(): UseQueryResult<string[], unknown> {
-  return useQuery(
-    'availableVideos',
-    () => fetch(`${bi.SERVER_URL}/${bi.GET_AVAILABLE_VIDEOS}`).then((res) => res.json()),
-    {
-      staleTime: Infinity
-    }
-  )
+  return useQuery('availableVideos', QUERIES.fetchAvailableVideos, {
+    staleTime: Infinity
+  })
 }
 
 export function useAllVideos(): UseQueryResult<IVideoFull[], unknown> {
-  return useQuery(
-    'allVideos',
-    () => fetch(`${bi.SERVER_URL}/${bi.GET_ALL_VIDEOS}`).then((res) => res.json()),
-    {
-      staleTime: Infinity
-    }
-  )
+  return useQuery('allVideos', QUERIES.fetchAllVideos, {
+    staleTime: Infinity
+  })
 }
 
 export function useVideo(videoPath: string): UseQueryResult<IVideoWithRelated, unknown> {
-  return useQuery(
-    ['allVideos', videoPath],
-    () =>
-      fetch(`${bi.SERVER_URL}/${bi.GET_VIDEO}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ videoPath: videoPath })
-      }).then((res) => res.json()),
-    {
-      staleTime: Infinity
-    }
-  )
+  return useQuery(['allVideos', videoPath], () => QUERIES.fetchVideo(videoPath), {
+    staleTime: Infinity
+  })
 }
 
 export function useCreateVideos(): [
@@ -48,42 +139,17 @@ export function useCreateVideos(): [
   boolean
 ] {
   const queryClient = useQueryClient()
-  const mutation = useMutation(
-    (videoPaths: string[]) =>
-      fetch(`${bi.SERVER_URL}/${bi.ADD_VIDEOS}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ videoPaths: videoPaths })
-      }),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(['availableVideos'])
-        queryClient.invalidateQueries(['allVideos'])
-        queryClient.invalidateQueries(['availableGalleries'])
-        queryClient.invalidateQueries(['allGalleries'])
-      }
-    }
-  )
+  const mutation = useMutation(QUERIES.createVideos, {
+    onSuccess: () => INVALIDATE_CACHES.createVideos(queryClient)
+  })
   return [mutation.mutate, mutation.isLoading]
 }
 
 export function useGenerateTgp(): [UseMutateFunction<unknown, unknown, string, unknown>, boolean] {
   const queryClient = useQueryClient()
-  const mutation = useMutation(
-    (videoPath: string) =>
-      fetch(`${bi.SERVER_URL}/${bi.GENERATE_TGP}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ videoPath: videoPath })
-      }).then(() => videoPath),
-    {
-      onSuccess: (videoPath) => {
-        queryClient.invalidateQueries(['availableVideos'])
-        queryClient.invalidateQueries(['allVideos'])
-        queryClient.invalidateQueries(['allVideos', videoPath])
-      }
-    }
-  )
+  const mutation = useMutation(QUERIES.generateTgp, {
+    onSuccess: () => INVALIDATE_CACHES.generateTgp(queryClient)
+  })
   return [mutation.mutate, mutation.isLoading]
 }
 
@@ -92,32 +158,17 @@ export function useGenerateMissingTgps(): [
   boolean
 ] {
   const queryClient = useQueryClient()
-  const mutation = useMutation(() => fetch(`${bi.SERVER_URL}/${bi.GENERATE_MISSING_TGPS}`), {
-    onSuccess: () => {
-      queryClient.invalidateQueries(['availableVideos'])
-      queryClient.invalidateQueries(['allVideos'])
-    }
+  const mutation = useMutation(QUERIES.generateMissingTgps, {
+    onSuccess: () => INVALIDATE_CACHES.generateMissingTgps(queryClient)
   })
   return [mutation.mutate, mutation.isLoading]
 }
 
 export function useDeleteVideo(): UseMutateFunction<unknown, unknown, string, unknown> {
   const queryClient = useQueryClient()
-  return useMutation(
-    (videoPathToRemove: string) =>
-      fetch(`${bi.SERVER_URL}/${bi.DELETE_VIDEO}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ videoPath: videoPathToRemove })
-      }).then(() => videoPathToRemove),
-    {
-      onSuccess: (videoPathToRemove) => {
-        queryClient.invalidateQueries(['availableVideos'])
-        queryClient.invalidateQueries(['allVideos'])
-        queryClient.invalidateQueries(['allVideos', videoPathToRemove])
-      }
-    }
-  ).mutate
+  return useMutation(QUERIES.deleteVideo, {
+    onSuccess: () => INVALIDATE_CACHES.deleteVideo(queryClient)
+  }).mutate
 }
 
 export function useDeleteMissingVideos(): [
@@ -125,11 +176,8 @@ export function useDeleteMissingVideos(): [
   boolean
 ] {
   const queryClient = useQueryClient()
-  const mutation = useMutation(() => fetch(`${bi.SERVER_URL}/${bi.DELETE_MISSING_VIDEOS}`), {
-    onSuccess: () => {
-      queryClient.invalidateQueries(['availableVideos'])
-      queryClient.invalidateQueries(['allVideos'])
-    }
+  const mutation = useMutation(QUERIES.deleteMissingVideos, {
+    onSuccess: () => INVALIDATE_CACHES.deleteMissingVideos(queryClient)
   })
   return [mutation.mutate, mutation.isLoading]
 }
@@ -141,21 +189,9 @@ export function useUpdateVideoGalleries(): UseMutateFunction<
   unknown
 > {
   const queryClient = useQueryClient()
-  return useMutation(
-    ([videoPath, galleriesDiffObj]: [string, IDiffObj]) =>
-      fetch(`${bi.SERVER_URL}/${bi.UPDATE_VIDEO_GALLERIES}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ videoPath: videoPath, diffObj: galleriesDiffObj })
-      }).then(() => videoPath),
-    {
-      onSuccess: (videoPath) => {
-        queryClient.invalidateQueries(['availableVideos'])
-        queryClient.invalidateQueries(['allVideos'])
-        queryClient.invalidateQueries(['allVideos', videoPath])
-      }
-    }
-  ).mutate
+  return useMutation(QUERIES.updateVideoGalleries, {
+    onSuccess: () => INVALIDATE_CACHES.updateVideoGalleries(queryClient)
+  }).mutate
 }
 
 export function useUpdateVideoTags(): UseMutateFunction<
@@ -165,19 +201,7 @@ export function useUpdateVideoTags(): UseMutateFunction<
   unknown
 > {
   const queryClient = useQueryClient()
-  return useMutation(
-    ([videoPath, tagsDiffObj]: [string, IDiffObj]) =>
-      fetch(`${bi.SERVER_URL}/${bi.UPDATE_VIDEO_TAGS}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ videoPath: videoPath, diffObj: tagsDiffObj })
-      }).then(() => videoPath),
-    {
-      onSuccess: (videoPath) => {
-        queryClient.invalidateQueries(['availableVideos'])
-        queryClient.invalidateQueries(['allVideos'])
-        queryClient.invalidateQueries(['allVideos', videoPath])
-      }
-    }
-  ).mutate
+  return useMutation(QUERIES.updateVideoTags, {
+    onSuccess: () => INVALIDATE_CACHES.updateVideoTags(queryClient)
+  }).mutate
 }

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from 'react-query'
+import { ReactQueryDevtools } from 'react-query/devtools'
 import App from './App'
 
 import 'rsuite/dist/rsuite.min.css'
@@ -12,6 +13,7 @@ const queryClient = new QueryClient()
 root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools initialIsOpen={false} />
       <App />
     </QueryClientProvider>
   </React.StrictMode>

--- a/src/renderer/src/pages/Gallery.tsx
+++ b/src/renderer/src/pages/Gallery.tsx
@@ -16,9 +16,9 @@ export default function Gallery(): JSX.Element {
   const updateGalleryVideos = useUpdateGalleryVideos()
 
   React.useEffect(() => {
-    if (!gallery.isLoading)
+    if (gallery.isSuccess)
       setSelectedVideos(new Set(gallery.data?.videos?.map((video: IVideoModel) => video.filePath)))
-  }, [gallery.isLoading])
+  }, [gallery.data])
 
   if (gallery.isLoading || allVideos.isLoading) return <CenterMessage msg="Loading..." />
 

--- a/src/renderer/src/pages/Tag.tsx
+++ b/src/renderer/src/pages/Tag.tsx
@@ -16,11 +16,11 @@ export default function Tag(): JSX.Element {
   const updateTagVideos = useUpdateTagVideos()
 
   React.useEffect(() => {
-    if (!tag.isLoading)
+    if (tag.isSuccess)
       setSelectedVideos(
         new Set(tag.data ? tag.data.videos.map((video: IVideoModel) => video.filePath) : [])
       )
-  }, [tag.isLoading])
+  }, [tag.data])
 
   if (tag.isLoading || allVideos.isLoading) return <CenterMessage msg="Loading..." />
 

--- a/src/renderer/src/pages/Video.tsx
+++ b/src/renderer/src/pages/Video.tsx
@@ -57,7 +57,7 @@ export default function Video(): JSX.Element {
         new Set(video.data.galleries.map((gallery: IGalleryModel) => gallery.galleryPath))
       )
     }
-  }, [video.isSuccess])
+  }, [video.data])
 
   const handleTabClick = (newTabId: string): void => {
     setIsVideoPlaying(false)


### PR DESCRIPTION
The react-query cache invalidation was not reflecting in the UI,
this was because the useEffect dependency was queryObject.isSuccess
Fixed it by changing the dependency to queryObject.data

Additional changes:
- Add missing package.json dependency lodash
- Add react-query devtools
- Refactor react-query hooks